### PR TITLE
Fix navigation and add placeholder pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # dheba160.github.io
+
+Simple portfolio-style site with animated starfield background. Pages include:
+- `index.html` – landing page
+- `about.html` – about me
+- `work.html` – portfolio
+- `contact.html` – contact details
+
+Each page features animated transitions and placeholder text for further customization.

--- a/about.html
+++ b/about.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Contact - Dennis Heba</title>
+    <title>About - Dennis Heba</title>
     
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -182,8 +182,8 @@
     <div class="page-container">
         <div class="content-wrapper">
             <section class="hero">
-                <h1 class="aurora-gradient">Contact</h1>
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec aliquet ipsum at sapien pellentesque, ut finibus risus sollicitudin.</p>
+                <h1 class="aurora-gradient">About Me</h1>
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla facilisi. Vivamus vel ligula nec leo fermentum blandit.</p>
             </section>
             <div class="button-container">
                 <!-- UPDATED: href attributes are now added -->

--- a/index.html
+++ b/index.html
@@ -30,6 +30,8 @@
             color: var(--text-color);
             overflow: hidden;
             height: 100%;
+            opacity: 0;
+            animation: page-fade-in 0.5s forwards;
         }
         
         #starfield-background {
@@ -145,6 +147,20 @@
             to { opacity: 1; transform: translateY(0); }
         }
 
+        .fade-out {
+            animation: page-fade-out 0.5s forwards;
+        }
+
+        @keyframes page-fade-in {
+            from { opacity: 0; }
+            to { opacity: 1; }
+        }
+
+        @keyframes page-fade-out {
+            from { opacity: 1; }
+            to { opacity: 0; }
+        }
+
         @media (max-width: 600px) {
             .hero h1 { font-size: 3.5rem; }
             .button-container { flex-direction: column; align-items: flex-start; }
@@ -171,13 +187,13 @@
             </section>
             <div class="button-container">
                 <!-- UPDATED: href attributes are now added -->
-                <a href="#work" class="aurora-button" id="btn-work">
+                <a href="work.html" class="aurora-button transition-link" id="btn-work">
                     <span class="content aurora-gradient">My Work</span>
                 </a>
-                <a href="#about" class="aurora-button" id="btn-about">
+                <a href="about.html" class="aurora-button transition-link" id="btn-about">
                     <span class="content aurora-gradient">About Me</span>
                 </a>
-                <a href="#contact" class="aurora-button" id="btn-contact">
+                <a href="contact.html" class="aurora-button transition-link" id="btn-contact">
                     <span class="content aurora-gradient">Contact</span>
                 </a>
             </div>
@@ -254,6 +270,16 @@
             }
             
             document.body.addEventListener('mousemove', revealButtonsOnFirstMove);
+
+            document.querySelectorAll('.transition-link').forEach(link => {
+                link.addEventListener('click', (e) => {
+                    e.preventDefault();
+                    document.body.classList.add('fade-out');
+                    setTimeout(() => {
+                        window.location.href = link.href;
+                    }, 500);
+                });
+            });
         });
     </script>
 </body>

--- a/work.html
+++ b/work.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Contact - Dennis Heba</title>
+    <title>Work - Dennis Heba</title>
     
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -182,8 +182,8 @@
     <div class="page-container">
         <div class="content-wrapper">
             <section class="hero">
-                <h1 class="aurora-gradient">Contact</h1>
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec aliquet ipsum at sapien pellentesque, ut finibus risus sollicitudin.</p>
+                <h1 class="aurora-gradient">My Work</h1>
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent eu nunc vel leo luctus laoreet.</p>
             </section>
             <div class="button-container">
                 <!-- UPDATED: href attributes are now added -->


### PR DESCRIPTION
## Summary
- update homepage buttons to link to new pages
- add simple fade-in/out page transitions
- create placeholder `about`, `work`, and `contact` pages
- clean up README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687675112130832f83691554cff3547c