### PR TITLE
Track earnings across pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -190,8 +190,8 @@
                 <a href="work.html" class="aurora-button transition-link" id="btn-work">
                     <span class="content aurora-gradient">My Work</span>
                 </a>
-                <a href="about.html" class="aurora-button transition-link" id="btn-about">
-                    <span class="content aurora-gradient">About Me</span>
+                <a href="index.html" class="aurora-button transition-link" id="btn-about">
+                    <span class="content aurora-gradient">Home</span>
                 </a>
                 <a href="contact.html" class="aurora-button transition-link" id="btn-contact">
                     <span class="content aurora-gradient">Contact</span>
@@ -239,9 +239,23 @@
                 gates: { name: 'Bill Gates', rate: 117 }
             };
             const personKeys = Object.keys(people);
-            const chosenPerson = people[personKeys[Math.floor(Math.random() * personKeys.length)]];
+
+            let chosenPersonKey = sessionStorage.getItem('chosenPersonKey');
+            if (!chosenPersonKey) {
+                chosenPersonKey = personKeys[Math.floor(Math.random() * personKeys.length)];
+                sessionStorage.setItem('chosenPersonKey', chosenPersonKey);
+            }
+            const chosenPerson = people[chosenPersonKey];
+
+            let startTime = sessionStorage.getItem('startTime');
+            if (!startTime) {
+                startTime = Date.now();
+                sessionStorage.setItem('startTime', startTime);
+            } else {
+                startTime = parseInt(startTime, 10);
+            }
+
             const earningsTextElement = document.getElementById('earnings-text');
-            const startTime = Date.now();
 
             function updateEarnings() {
                 const elapsedTimeMs = Date.now() - startTime;

--- a/contact.html
+++ b/contact.html
@@ -193,8 +193,8 @@
                 <a href="about.html" class="aurora-button transition-link" id="btn-about">
                     <span class="content aurora-gradient">About Me</span>
                 </a>
-                <a href="contact.html" class="aurora-button transition-link" id="btn-contact">
-                    <span class="content aurora-gradient">Contact</span>
+                <a href="index.html" class="aurora-button transition-link" id="btn-contact">
+                    <span class="content aurora-gradient">Home</span>
                 </a>
             </div>
         </div>
@@ -239,9 +239,23 @@
                 gates: { name: 'Bill Gates', rate: 117 }
             };
             const personKeys = Object.keys(people);
-            const chosenPerson = people[personKeys[Math.floor(Math.random() * personKeys.length)]];
+
+            let chosenPersonKey = sessionStorage.getItem('chosenPersonKey');
+            if (!chosenPersonKey) {
+                chosenPersonKey = personKeys[Math.floor(Math.random() * personKeys.length)];
+                sessionStorage.setItem('chosenPersonKey', chosenPersonKey);
+            }
+            const chosenPerson = people[chosenPersonKey];
+
+            let startTime = sessionStorage.getItem('startTime');
+            if (!startTime) {
+                startTime = Date.now();
+                sessionStorage.setItem('startTime', startTime);
+            } else {
+                startTime = parseInt(startTime, 10);
+            }
+
             const earningsTextElement = document.getElementById('earnings-text');
-            const startTime = Date.now();
 
             function updateEarnings() {
                 const elapsedTimeMs = Date.now() - startTime;

--- a/index.html
+++ b/index.html
@@ -239,9 +239,23 @@
                 gates: { name: 'Bill Gates', rate: 117 }
             };
             const personKeys = Object.keys(people);
-            const chosenPerson = people[personKeys[Math.floor(Math.random() * personKeys.length)]];
+
+            let chosenPersonKey = sessionStorage.getItem('chosenPersonKey');
+            if (!chosenPersonKey) {
+                chosenPersonKey = personKeys[Math.floor(Math.random() * personKeys.length)];
+                sessionStorage.setItem('chosenPersonKey', chosenPersonKey);
+            }
+            const chosenPerson = people[chosenPersonKey];
+
+            let startTime = sessionStorage.getItem('startTime');
+            if (!startTime) {
+                startTime = Date.now();
+                sessionStorage.setItem('startTime', startTime);
+            } else {
+                startTime = parseInt(startTime, 10);
+            }
+
             const earningsTextElement = document.getElementById('earnings-text');
-            const startTime = Date.now();
 
             function updateEarnings() {
                 const elapsedTimeMs = Date.now() - startTime;

--- a/work.html
+++ b/work.html
@@ -187,8 +187,8 @@
             </section>
             <div class="button-container">
                 <!-- UPDATED: href attributes are now added -->
-                <a href="work.html" class="aurora-button transition-link" id="btn-work">
-                    <span class="content aurora-gradient">My Work</span>
+                <a href="index.html" class="aurora-button transition-link" id="btn-work">
+                    <span class="content aurora-gradient">Home</span>
                 </a>
                 <a href="about.html" class="aurora-button transition-link" id="btn-about">
                     <span class="content aurora-gradient">About Me</span>
@@ -239,9 +239,23 @@
                 gates: { name: 'Bill Gates', rate: 117 }
             };
             const personKeys = Object.keys(people);
-            const chosenPerson = people[personKeys[Math.floor(Math.random() * personKeys.length)]];
+
+            let chosenPersonKey = sessionStorage.getItem('chosenPersonKey');
+            if (!chosenPersonKey) {
+                chosenPersonKey = personKeys[Math.floor(Math.random() * personKeys.length)];
+                sessionStorage.setItem('chosenPersonKey', chosenPersonKey);
+            }
+            const chosenPerson = people[chosenPersonKey];
+
+            let startTime = sessionStorage.getItem('startTime');
+            if (!startTime) {
+                startTime = Date.now();
+                sessionStorage.setItem('startTime', startTime);
+            } else {
+                startTime = parseInt(startTime, 10);
+            }
+
             const earningsTextElement = document.getElementById('earnings-text');
-            const startTime = Date.now();
 
             function updateEarnings() {
                 const elapsedTimeMs = Date.now() - startTime;


### PR DESCRIPTION
## Summary
- persist chosen billionaire and earnings timer across pages using `sessionStorage`
- convert page-specific buttons into links back to the homepage when viewing About, Work, or Contact pages

## Testing
- `html5validator --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687676c4213c832fa5919b73cb4c5559