### PR TITLE
Center layout on all pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -65,7 +65,8 @@
         
         .content-wrapper {
             max-width: 800px;
-            text-align: left;
+            margin: 0 auto;
+            text-align: center;
         }
 
         .aurora-gradient {
@@ -99,6 +100,7 @@
         .button-container {
             display: flex;
             gap: 1.5rem;
+            justify-content: center;
         }
 
         .aurora-button {

--- a/contact.html
+++ b/contact.html
@@ -65,7 +65,8 @@
         
         .content-wrapper {
             max-width: 800px;
-            text-align: left;
+            margin: 0 auto;
+            text-align: center;
         }
 
         .aurora-gradient {
@@ -99,6 +100,7 @@
         .button-container {
             display: flex;
             gap: 1.5rem;
+            justify-content: center;
         }
 
         .aurora-button {

--- a/privacy.html
+++ b/privacy.html
@@ -6,6 +6,29 @@
     <title>Privacy Policy</title>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
+    <style>
+        body {
+            font-family: "Poppins", sans-serif;
+            background: #0A0A0A;
+            color: #EAEAEA;
+            margin: 0;
+            height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+        .privacy-section {
+            flex: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 2rem;
+        }
+        .privacy-container {
+            max-width: 800px;
+            margin: 0 auto;
+            text-align: center;
+        }
+    </style>
 </head>
 <body>
     <header class="main-header">

--- a/work.html
+++ b/work.html
@@ -65,7 +65,8 @@
         
         .content-wrapper {
             max-width: 800px;
-            text-align: left;
+            margin: 0 auto;
+            text-align: center;
         }
 
         .aurora-gradient {
@@ -99,6 +100,7 @@
         .button-container {
             display: flex;
             gap: 1.5rem;
+            justify-content: center;
         }
 
         .aurora-button {


### PR DESCRIPTION
## Summary
- center page content and buttons on About, Contact, and Work pages
- add simple centered layout styling to privacy page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876d41bb4cc832fb1ea8c95b8d0fec6